### PR TITLE
Adding "Code_Of_Conduct.md", thanks @mannubaveja007 for the Opportunity and looking forward to continuing more

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# CODE_OF_CONDUCT
+
+----
+
+# Smart Notes (Auralis) Project's Code of Conduct
+
+## 1. Our Commitment
+
+The Smart Notes (Auralis) project is built to empower learners, developers, and open-source contributors from all walks of life. Whether you’re fixing a typo or designing a whole new feature, every contribution matters. We are committed to ensuring a respectful, welcoming, and inclusive space for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## 2. Our Core Values & Contributor Expectations
+
+We believe our community thrives when all participants adhere to the following values and expectations:
+
+### Core Values:
+* **Encourage open communication and knowledge sharing.**
+* **Welcome new ideas, diverse perspectives, and honest questions.**
+* **Support and uplift contributors at all skill levels.**
+* **Respect others' time, feedback, and creativity.**
+* **Create with curiosity, code with care.**
+* **Work together transparently and collaboratively.**
+
+### Contributor Expectations:
+* **Collaborate respectfully and constructively.**
+* **Maintain integrity and credit all sources.**
+* **Embrace learning and be open to feedback.**
+* **Avoid offensive, unethical, or AI-generated content without review.**
+* **Help make Smart Notes (Auralis) a safe, beginner-friendly environment.**
+
+## 3. Unacceptable Behavior
+
+To maintain a safe and productive space, we do not tolerate the following in any project spaces:
+
+* Disrespectful, rude, or hostile interactions.
+* Harassment, intimidation, or personal attacks.
+* Plagiarism, spamming, or irrelevant promotions.
+* Gatekeeping or excluding others from discussions.
+* Discrimination based on gender, race, religion, identity, or background.
+* The use of sexualized language or imagery, and unwelcome sexual attention or advances.
+* Trolling, insulting, or derogatory comments.
+* Publishing others' private information, such as a physical or electronic address, without explicit permission.
+
+## 4. Scope and Applicability
+
+This Code of Conduct applies to all spaces where the Smart Notes (Auralis) project is represented:
+
+* **GitHub repository & discussions**
+* **Pull requests, issues, and commit comments**
+* **Project-related events, forums, and social media**
+* **Any other platform or medium connected to the Smart Notes project**
+
+## 5. Enforcement and Consequences
+
+We are serious about our community standards. The project maintainers will investigate any violations of this Code of Conduct promptly and fairly.
+
+* **Reporting Concerns:** If you experience or observe behavior that violates these guidelines, please notify a **Project Admin or WOCS Mentor** (if applicable) or contact the maintainers directly via email. Please send detailed reports to **[MAINTAINER_EMAIL_ADDRESS]**. All concerns will be handled with seriousness, respect, and confidentiality.
+* **Maintainer Responsibility:** Project maintainers are responsible for clarifying standards and taking appropriate corrective action. Maintainers are obligated to respect the privacy and security of the reporter.
+* **Consequences of Violations:** We reserve the right to take appropriate action, which may include:
+    * **Reminder** of the guidelines
+    * **Formal warning**
+    * **Temporary exclusion** from contributions
+    * **Permanent ban** from the project's repositories and discussion groups.
+
+## 6. Attribution
+
+This Code of Conduct aligns with the principles of **WOCS’25** and reflects our collective commitment to mentorship, inclusivity, and ethical open-source contribution.
+
+It is inspired by the **Contributor Covenant, Version 3.0**, available at [https://www.contributor-covenant.org/version/3/0/code_of_conduct/](https://www.contributor-covenant.org/version/3/0/code_of_conduct/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,7 +51,7 @@ This Code of Conduct applies to all spaces where the Smart Notes (Auralis) proje
 
 We are serious about our community standards. The project maintainers will investigate any violations of this Code of Conduct promptly and fairly.
 
-* **Reporting Concerns:** If you experience or observe behavior that violates these guidelines, please notify a **Project Admin or WOCS Mentor** (if applicable) or contact the maintainers directly via email. Please send detailed reports to **[MAINTAINER_EMAIL_ADDRESS]**. All concerns will be handled with seriousness, respect, and confidentiality.
+* **Reporting Concerns:** If you experience or observe behavior that violates these guidelines, please notify a **Project Admin or WOCS Mentor** (if applicable) or contact the maintainers directly via email. Please send detailed reports to @mannubaveja007 **[MAINTAINER_EMAIL_ADDRESS]**. All concerns will be handled with seriousness, respect, and confidentiality.
 * **Maintainer Responsibility:** Project maintainers are responsible for clarifying standards and taking appropriate corrective action. Maintainers are obligated to respect the privacy and security of the reporter.
 * **Consequences of Violations:** We reserve the right to take appropriate action, which may include:
     * **Reminder** of the guidelines

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,9 @@
 # CODE_OF_CONDUCT
 
 ----
+<img width="1710" height="846" alt="image" src="https://github.com/user-attachments/assets/30a4a0a0-9d13-4f60-b245-0cb356d472dc" />
+
+
 
 # Smart Notes (Auralis) Project's Code of Conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,5 @@
 # CODE_OF_CONDUCT
 
-----
-<img width="1710" height="846" alt="image" src="https://github.com/user-attachments/assets/30a4a0a0-9d13-4f60-b245-0cb356d472dc" />
-
-
-
 # Smart Notes (Auralis) Project's Code of Conduct
 
 ## 1. Our Commitment

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,8 @@
-# CODE_OF_CONDUCT
-
-# Smart Notes (Auralis) Project's Code of Conduct
+# Smart Notes (Auralis) Project Code of Conduct
 
 ## 1. Our Commitment
 
-The Smart Notes (Auralis) project is built to empower learners, developers, and open-source contributors from all walks of life. Whether you’re fixing a typo or designing a whole new feature, every contribution matters. We are committed to ensuring a respectful, welcoming, and inclusive space for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+The **[Smart Notes (Auralis)](https://auralis.appwrite.network/)** project is built to empower learners, developers, and open-source contributors from all walks of life. Whether you’re fixing a typo or designing a whole new feature, every contribution matters. We are committed to ensuring a respectful, welcoming, and inclusive space for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## 2. Our Core Values & Contributor Expectations
 
@@ -51,7 +49,7 @@ This Code of Conduct applies to all spaces where the Smart Notes (Auralis) proje
 
 We are serious about our community standards. The project maintainers will investigate any violations of this Code of Conduct promptly and fairly.
 
-* **Reporting Concerns:** If you experience or observe behavior that violates these guidelines, please notify a **Project Admin or WOCS Mentor** (if applicable) or contact the maintainers directly via email. Please send detailed reports to @mannubaveja007 **[MAINTAINER_EMAIL_ADDRESS]**. All concerns will be handled with seriousness, respect, and confidentiality.
+* **Reporting Concerns:** If you experience or observe behavior that violates these guidelines, please notify a **Project Admin or WOCS Mentor** (if applicable) or contact the maintainers directly via email. Please send detailed reports to **[INSERT CONFIDENTIAL CONTACT EMAIL]**. All concerns will be handled with seriousness, respect, and confidentiality.
 * **Maintainer Responsibility:** Project maintainers are responsible for clarifying standards and taking appropriate corrective action. Maintainers are obligated to respect the privacy and security of the reporter.
 * **Consequences of Violations:** We reserve the right to take appropriate action, which may include:
     * **Reminder** of the guidelines


### PR DESCRIPTION
### PR Title: `docs: Add comprehensive CODE_OF_CONDUCT.md and update CONTRIBUTING.md link`

### Description:

This Pull Request addresses the open issue of adding a formal Code of Conduct to the repository (Issue #4 

It introduces a comprehensive `CODE_OF_CONDUCT.md` based on community best practices and project-specific values, and ensures all project documentation references the new file.

### Key Changes:

1.  **New File: `CODE_OF_CONDUCT.md`**
    * Adds a detailed Code of Conduct based on the **Contributor Covenant, Version 3.0**, tailored specifically for the Smart Notes (Auralis) project.
    * Defines clear **Core Values** (e.g., open communication, welcoming newcomers) and **Contributor Expectations** (e.g., collaborate respectfully, embrace learning).
    * Clearly outlines **Unacceptable Behavior**, **Scope**, and **Enforcement** policies (warning, temporary ban, permanent ban).
    * Includes attribution to the Contributor Covenant and aligns with the principles of **WOCS'25** (Women in Open Source Coding).
    * Hyperlinks the project name, **[[Smart Notes (Auralis)](https://auralis.appwrite.network/)](https://auralis.appwrite.network/)**, in the first section.

2.  **Updated File: `CONTRIBUTING.md`**
    * Verifies and confirms the existing markdown link points correctly to the new `CODE_OF_CONDUCT.md` file.

### Why This Change Is Important:

* **Fosters an Inclusive Environment:** A clear Code of Conduct is essential for maintaining a respectful, welcoming, and harassment-free environment for contributors from all backgrounds.
* **Clarifies Expectations:** It sets explicit standards for acceptable professional behavior within all project spaces (GitHub, discussions, events).
* **Fulfills Open Source Requirement:** It aligns the project with modern open-source best practices, aiding in program participation and community growth.

### Linked Issues:

Closes #4 

### Contribution Tags:

* `wocs`
* `level 1` (or the appropriate difficulty level)
* `documentation`