### PR TITLE
Add Search Functionality to Filter Notes by Title, Tags, or Content

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -48,6 +48,7 @@ function Dashboard() {
   const [summarizing, setSummarizing] = useState<string | null>(null);
   const [insights, setInsights] = useState<string[]>([]);
   const [drawingNote, setDrawingNote] = useState<Note | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     if (user) {
@@ -199,6 +200,16 @@ function Dashboard() {
     return new Date(b.$createdAt || 0).getTime() - new Date(a.$createdAt || 0).getTime();
   });
 
+  // Filter notes based on search query
+  const filteredNotes = sortedNotes.filter((note) => {
+    const lowerCaseQuery = searchQuery.toLowerCase();
+    return (
+      note.title.toLowerCase().includes(lowerCaseQuery) ||
+      note.content.toLowerCase().includes(lowerCaseQuery) ||
+      (note.tags && note.tags.some((tag) => tag.toLowerCase().includes(lowerCaseQuery)))
+    );
+  });
+
   return (
     <div className="min-h-screen relative">
       {/* Squares Background */}
@@ -310,6 +321,19 @@ function Dashboard() {
           )}
         </div>
 
+        {/* Search Bar */}
+        {activeTab === 'notes' && (
+          <div className="mb-6">
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search notes by title, content, or tags..."
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+            />
+          </div>
+        )}
+
         {/* Content */}
         <AnimatePresence mode="wait">
           {activeTab === 'notes' ? (
@@ -320,7 +344,7 @@ function Dashboard() {
               exit={{ opacity: 0, y: -20 }}
               className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
             >
-              {sortedNotes.map((note) => (
+              {filteredNotes.map((note) => (
                 <NoteCard
                   key={note.$id}
                   note={note}


### PR DESCRIPTION
## Description:

This PR introduces a search bar to the notes dashboard, allowing users to filter their notes by title, tags, or content keywords. The search is performed client-side for fast, responsive filtering. The UI remains accessible and responsive across devices. This enhancement improves usability, especially as the number of notes grows.

## Before:

- Users could only view all notes in the dashboard with no way to quickly find specific notes.
- No search bar or filtering options were available.

<img width="1917" height="846" alt="image" src="https://github.com/user-attachments/assets/18f45d6c-975c-4ddd-9a9e-cde848371669" />


---
## After:

- A search bar appears above the notes grid when viewing notes.
- Users can filter notes in real-time by typing keywords that match the note’s title, tags, or content.
- The notes list updates dynamically as the user types, making it easier to find relevant notes quickly.

### Image of Search Bar present above the cards:
<img width="1917" height="846" alt="image" src="https://github.com/user-attachments/assets/b31a6e70-f5b5-48e3-9216-7a6cd4777978" />


### Below Screenshot showing search functionality is working:
<img width="1917" height="846" alt="image" src="https://github.com/user-attachments/assets/b70f79a1-8dae-4082-becd-74b08ca0feaa" />

