### PR TITLE
Add "Favorite Notes" Feature with Star Toggle and Favorites Tab

### DIFF
--- a/lib/notes.ts
+++ b/lib/notes.ts
@@ -49,6 +49,7 @@ export const notesService = {
     if (data.tags !== undefined && data.tags !== null) updateData.tags = data.tags;
     if (data.drawing !== undefined) updateData.drawing = data.drawing;
     if (data.pinned !== undefined) updateData.pinned = data.pinned;
+    if (data.favorite !== undefined) updateData.favorite = data.favorite;
 
     // Make sure we have at least one field to update
     if (Object.keys(updateData).length === 0) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export interface Note {
   drawing?: string; // JSON string of Excalidraw data
   pinned?: boolean; // Pin note to top
   userId: string;
+  favorite?: boolean; // Mark note as favorite
 }
 
 export interface User {


### PR DESCRIPTION
## Description:

This PR introduces a "Favorite Notes" feature to the dashboard. Users can now mark notes as favorites using a star icon on each note card. A new "Favorites" tab displays only the starred notes for quick access. The favorite status is stored in the Appwrite database and persists across sessions.


## Before:

- No way to mark notes as favorites.
- All notes shown together; no quick access to important notes.
- No visual indicator for favorite notes.

## After

- Each note card has a star icon to toggle favorite status.
- "Favorites" tab shows only starred notes.
- Favorited notes have a highlighted star and accent border.
- Favorite status is saved in Appwrite and persists across sessions.

## Outcome:
Users can easily organize and access their most important notes, improving productivity and user experience.

## Appwrite Database Update:

Add a new attribute to your notes collection in Appwrite:

Name: favorite
Type: Boolean
Default: false
Required: No

---

## Screenshots:

<img width="1913" height="590" alt="Screenshot from 2025-11-09 15-00-12" src="https://github.com/user-attachments/assets/31c521b7-2a9b-487f-b4d4-9f7678ae0c82" />

<img width="1913" height="590" alt="Screenshot from 2025-11-09 15-00-18" src="https://github.com/user-attachments/assets/4f1bfb29-db6d-4e23-a33d-07c07152f832" />

