### PR TITLE
add pading in logo

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -270,7 +270,7 @@ function Dashboard() {
                   colors={['#3b82f6', '#8b5cf6', '#ec4899', '#8b5cf6', '#3b82f6']}
                   animationSpeed={6}
                 >
-                  <h1 className="text-3xl font-bold tracking-tight">Auralis</h1>
+                  <h1 className="text-3xl font-bold tracking-tight px-3 py-2">Auralis</h1>
                 </GradientText>
                 <motion.p
                   initial={{ opacity: 0 }}


### PR DESCRIPTION
Now : 
<img width="1258" height="96" alt="Screenshot 2025-11-10 at 11 28 25 PM" src="https://github.com/user-attachments/assets/0666b804-8449-47ec-ae3c-988863ae8eca" />

Before :
<img width="1268" height="132" alt="512307932-efe5fd2f-5917-4363-8de3-346a1502fe07" src="https://github.com/user-attachments/assets/da793099-c099-400d-9e7b-5b2f879c1adc" />
